### PR TITLE
/certification/all API 수정

### DIFF
--- a/src/main/java/com/delgo/reward/controller/CertController.java
+++ b/src/main/java/com/delgo/reward/controller/CertController.java
@@ -178,7 +178,7 @@ public class CertController extends CommController {
      * Response Data : 인증 모두 조회 ( 페이징 처리 되어 있음 )
      */
     @GetMapping("/all")
-    public ResponseEntity getPagingData(
+    public ResponseEntity getAllData(
             @RequestParam Integer userId,
             @RequestParam(required = false) Integer certificationId,
             @PageableDefault(sort = "registDt", direction = Sort.Direction.DESC) Pageable pageable) {

--- a/src/main/java/com/delgo/reward/dto/comm/PageResDTO.java
+++ b/src/main/java/com/delgo/reward/dto/comm/PageResDTO.java
@@ -1,0 +1,25 @@
+package com.delgo.reward.dto.comm;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class PageResDTO<T,F> {
+    private int size;
+    private int number;
+    private boolean last;
+    private List<T> content;
+
+    public PageResDTO(List<T> data, Slice<F> slice) {
+        this.content = data;
+        size = slice.getSize();
+        number = slice.getNumber();
+        last = !slice.hasNext();
+    }
+}

--- a/src/main/java/com/delgo/reward/repository/CertRepository.java
+++ b/src/main/java/com/delgo/reward/repository/CertRepository.java
@@ -37,10 +37,6 @@ public interface CertRepository extends JpaRepository<Certification, Integer>, J
     List<Certification> findCertByDateAndUser(@Param("userId") int userId, @Param("startDt") LocalDateTime startDt, @Param("endDt") LocalDateTime endDate);
 
     @EntityGraph(attributePaths = {"user", "likeLists"})
-    @Query(value = "select c from Certification c where c.user.userId  not in (select b.banUserId from BanList b where b.userId = :userId) and c.isCorrectPhoto = true")
-    Slice<Certification> findAllByPaging(@Param("userId") int userId, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"user", "likeLists"})
     @Query(value = "select c from Certification c where c.mungpleId = :mungpleId and c.isCorrectPhoto = true")
     Slice<Certification> findCertByMungple(@Param("mungpleId") int mungpleId, Pageable pageable);
 
@@ -51,10 +47,6 @@ public interface CertRepository extends JpaRepository<Certification, Integer>, J
     @EntityGraph(attributePaths = {"user", "likeLists"})
     @Query(value = "SELECT c FROM Certification c where c.isExpose = true and c.isCorrectPhoto = true order by RAND()")
     List<Certification> findByIsExpose(Pageable pageable);
-
-    @EntityGraph(attributePaths = {"user", "likeLists"})
-    @Query(value = "select c from Certification c where c.user.userId not in (select b.banUserId from BanList b where b.userId = :userId) and c.certificationId != :certificationId and c.isCorrectPhoto = true")
-    Slice<Certification> findAllExcludeSpecificCert(@Param("userId") int userId, @Param("certificationId") int certificationId, Pageable pageable);
 
     @Query(value = "select count(c) from Certification c where c.user.userId = :userId and c.mungpleId != 0")
     Integer countOfCertByMungpleAndUser(@Param("userId") int userId);
@@ -73,4 +65,16 @@ public interface CertRepository extends JpaRepository<Certification, Integer>, J
 
     @Query(value = "select c from Certification c where c.registDt between :startDt and :endDt order by c.registDt desc")
     List<Certification> findCertByDate(@Param("startDt") LocalDateTime startDt, @Param("endDt") LocalDateTime endDate);
+
+
+
+    @EntityGraph(attributePaths = {"likeLists"})
+    @Query("SELECT DISTINCT c FROM Certification c JOIN FETCH c.user u JOIN FETCH u.pet WHERE c.certificationId IN :ids")
+    List<Certification> findCertByIds(@Param("ids") List<Integer> ids);
+
+    @Query(value = "select c.certificationId from Certification c where c.user.userId  not in (select b.banUserId from BanList b where b.userId = :userId) and c.isCorrectPhoto = true")
+    Slice<Integer> findAllCertIdByPaging(@Param("userId") int userId, Pageable pageable);
+
+    @Query(value = "select c.certificationId from Certification c where c.user.userId not in (select b.banUserId from BanList b where b.userId = :userId) and c.certificationId != :certificationId and c.isCorrectPhoto = true")
+    Slice<Integer> findAllExcludeSpecificCert(@Param("userId") int userId, @Param("certificationId") int certificationId, Pageable pageable);
 }


### PR DESCRIPTION
- Pagaing, EntityGraph 같이 사용시 메모리 과부하 발생 따라서 코드 분리 필요
- PageResDTO 반환객체 생성