### PR TITLE
FIX: Apple 회원가입 수정

### DIFF
--- a/src/main/java/com/delgo/reward/record/signup/OAuthSignUpRecord.java
+++ b/src/main/java/com/delgo/reward/record/signup/OAuthSignUpRecord.java
@@ -29,7 +29,7 @@ public record OAuthSignUpRecord(
         return switch (userSocial) {
             case A -> User.builder()
                     .name(userName)
-                    .email(email)
+                    .email(null)
                     .phoneNo(phoneNo.replaceAll("[^0-9]", ""))
                     .userSocial(userSocial)
                     .address(address)


### PR DESCRIPTION
- 애플 회원가입 시 email을 알 수 없어 ""값을 설정
- DB에서 email이 UNIQUE로 설정되어 있어서 중복 허용 X
- DB에서 null허용으로 변경 후 "" -> null 값으로 변경 값으로 변경