### PR TITLE
FIX: Access, Refresh Token 형식 수정

### DIFF
--- a/src/main/java/com/delgo/reward/comm/security/jwt/JwtService.java
+++ b/src/main/java/com/delgo/reward/comm/security/jwt/JwtService.java
@@ -9,10 +9,7 @@ import com.delgo.reward.comm.security.jwt.config.AccessTokenProperties;
 import com.delgo.reward.comm.security.jwt.config.RefreshTokenProperties;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.Date;
 
 
@@ -47,44 +44,23 @@ public class JwtService {
     }
 
     /**
-     * Header에서 X-ACCESS-TOKEN 으로 JWT 추출
-     *
-     * @return String
-     **/
-    public String getAccessToken() {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-        return request.getHeader(AccessTokenProperties.HEADER_STRING).replace(AccessTokenProperties.TOKEN_PREFIX, "");
-    }
-
-    /**
-     * Header에서 X-REFRESH-TOKEN 으로 JWT 추출
-     *
-     * @return String
-     **/
-    public String getRefreshToken() {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-        return request.getHeader(RefreshTokenProperties.HEADER_STRING).replace(RefreshTokenProperties.TOKEN_PREFIX, "");
-    }
-
-    /**
      * JWT에서 userId 추출
      *
      * @return int
      * @throws JwtException
      */
-    public Integer getUserIdByAccessToken() throws JwtException {
-        String accessToken = getAccessToken();
-        if (accessToken == null || accessToken.length() == 0)
+    public Integer getUserIdByRefreshToken(String refreshToken) throws JwtException {
+        if (refreshToken == null || refreshToken.length() == 0)
             throw new JwtException(APICode.TOKEN_ERROR);
 
-        return Integer.parseInt(String.valueOf(JWT.require(Algorithm.HMAC512(AccessTokenProperties.SECRET)).build().verify(accessToken).getClaim("userId")));
-    }
-
-    public Integer getUserIdByRefreshToken() throws JwtException {
-        String refreshToken = getRefreshToken();
-        if (refreshToken == null || refreshToken.length() == 0) throw new JwtException(APICode.TOKEN_ERROR);
-
-        return Integer.parseInt(String.valueOf(JWT.require(Algorithm.HMAC512(RefreshTokenProperties.SECRET)).build().verify(refreshToken).getClaim("userId")));
+        return Integer.parseInt(
+                String.valueOf(
+                        JWT.require(Algorithm.HMAC512(RefreshTokenProperties.SECRET))
+                                .build()
+                                .verify(refreshToken) // Token 유효성 검증
+                                .getClaim("userId")
+                )
+        );
     }
 }
 

--- a/src/main/java/com/delgo/reward/comm/security/jwt/config/AccessTokenProperties.java
+++ b/src/main/java/com/delgo/reward/comm/security/jwt/config/AccessTokenProperties.java
@@ -2,7 +2,7 @@ package com.delgo.reward.comm.security.jwt.config;
 
 public interface AccessTokenProperties {
 	String SECRET = "Access_Delgo_Reward_SecretKey"; // Key 값
-	int EXPIRATION_TIME = 60000 * 60 * 24; // 1분 * 60 * 24 = 1일
+	int EXPIRATION_TIME = 60000 * 30; // 1분 * 30 = 30분
 	String TOKEN_PREFIX = "Access ";
 	String HEADER_STRING = "Authorization_Access";
 }

--- a/src/main/java/com/delgo/reward/comm/security/jwt/config/RefreshTokenProperties.java
+++ b/src/main/java/com/delgo/reward/comm/security/jwt/config/RefreshTokenProperties.java
@@ -2,7 +2,7 @@ package com.delgo.reward.comm.security.jwt.config;
 
 public interface RefreshTokenProperties {
 	String SECRET = "Refresh_Delgo_Reward_SecretKey"; // Key 값
-	Long EXPIRATION_TIME = 60000L * 60 * 24 * 30; // 1분 * 60 * 24 * 30 = 30일
+	Long EXPIRATION_TIME = 60000L * 60 * 24 * 7; // 1분 * 60 * 24 * 7 = 일주일
 	String TOKEN_PREFIX = "Refresh ";
 	String HEADER_STRING = "Authorization_Refresh";
 }

--- a/src/main/java/com/delgo/reward/comm/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/delgo/reward/comm/security/jwt/filter/JwtAuthenticationFilter.java
@@ -31,8 +31,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
             throws AuthenticationException {
 
-//        log.info("JwtAuthenticationFilter : 진입");
-
         ObjectMapper om = new ObjectMapper();
         LoginRecord loginRecord = null;
         try {
@@ -41,12 +39,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             e.printStackTrace();
         }
 
-//        log.info("JwtAuthenticationFilter : " + loginDTO);
-
         // 유저네임패스워드 토큰 생성
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginRecord.email(), loginRecord.password());
-
-//        log.info("JwtAuthenticationFilter : 토큰생성완료");
 
         // authenticate() 함수가 호출 되면 인증 프로바이더가 유저 디테일 서비스의
         // loadUserByUsername(토큰의 첫번째 파라메터) 를 호출하고
@@ -60,7 +54,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         Authentication authentication = authenticationManager.authenticate(authenticationToken);
 
         PrincipalDetails principalDetailis = (PrincipalDetails) authentication.getPrincipal();
-        log.info("Authentication : " + principalDetailis.getUser().getEmail());
         return authentication;
     }
 


### PR DESCRIPTION
- Access Token 기존과 같이 Header로 반환
- Refresh Token Cookie(httponly, secure, Strict)에 담아서 반환

- 보안상의 이유로 유효기간 변경
* Access 유효기간 1일 -> 30분으로 변경
* Refresh 유효기간 30일 -> 7일로 변경