### PR TITLE
FIX: SecurityConfig 수정

### DIFF
--- a/src/main/java/com/delgo/reward/comm/security/SecurityConfig.java
+++ b/src/main/java/com/delgo/reward/comm/security/SecurityConfig.java
@@ -76,6 +76,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
 				.antMatchers("/api/photo/mungple/*").permitAll()
 				.antMatchers("/api/photo/achievements/*").permitAll()
 				.antMatchers("/api/mungple").permitAll()
+				.antMatchers("/api/mungple/detail").permitAll()
 				.antMatchers("/api/mungple/category/*").permitAll()
 				.antMatchers("/health-check").permitAll()
 				.antMatchers("/kafka/**").permitAll()


### PR DESCRIPTION
- .antMatchers("/api/mungple/detail").permitAll() 추가
  * 비 로그인 시에도 디테일 페이지에 접근 가능해야 함.