### PR TITLE
FIX: MungpleDetail 조회 API 수정

### DIFF
--- a/src/main/java/com/delgo/reward/controller/MungpleController.java
+++ b/src/main/java/com/delgo/reward/controller/MungpleController.java
@@ -92,9 +92,6 @@ public class MungpleController extends CommController {
      */
     @GetMapping("/detail")
     public ResponseEntity getMungpleDetailByMungpleId(@RequestParam int mungpleId) {
-        return SuccessReturn(
-                new MungpleDetailResDTO(
-                        mongoMungpleService.getMungpleByMungpleId(mungpleId),
-                        certService.getCertCountByMungple(mungpleId)));
+        return SuccessReturn(mongoMungpleService.getMungpleDetailByMungpleId(mungpleId));
     }
 }

--- a/src/main/java/com/delgo/reward/mongoService/MongoMungpleService.java
+++ b/src/main/java/com/delgo/reward/mongoService/MongoMungpleService.java
@@ -8,6 +8,9 @@ import com.delgo.reward.comm.ncp.storage.BucketName;
 import com.delgo.reward.comm.ncp.storage.ObjectStorageService;
 import com.delgo.reward.domain.common.Location;
 import com.delgo.reward.dto.mungple.MungpleResDTO;
+import com.delgo.reward.dto.mungple.detail.MungpleDetailByMenuResDTO;
+import com.delgo.reward.dto.mungple.detail.MungpleDetailByPriceTagResDTO;
+import com.delgo.reward.dto.mungple.detail.MungpleDetailResDTO;
 import com.delgo.reward.mongoDomain.MongoMungple;
 import com.delgo.reward.mongoDomain.MungpleDetail;
 import com.delgo.reward.mongoRepository.MongoMungpleRepository;
@@ -154,6 +157,20 @@ public class MongoMungpleService {
         query.addCriteria(Criteria.where("location").withinSphere(new Circle(Double.parseDouble(longitude), Double.parseDouble(latitude), maxDistanceInRadians)));
 
         return mongoTemplate.find(query, MongoMungple.class);
+    }
+
+    public MungpleDetailResDTO getMungpleDetailByMungpleId(int mungpleId) {
+        MongoMungple mongoMungple = getMungpleByMungpleId(mungpleId);
+        int certCount = certRepository.countOfCertByMungple(mungpleId);
+
+        switch (CategoryCode.valueOf(mongoMungple.getCategoryCode())) {
+            case CA0002, CA0003 -> {
+                return new MungpleDetailByMenuResDTO(mongoMungple, certCount);
+            }
+            default -> {
+                return new MungpleDetailByPriceTagResDTO(mongoMungple, certCount);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
 - MungpleDetail은 카테고리별로 DTO 구분해줘야 함.
 * CA0002, CA0003 - MungpleDetailByMenuResDTO
 * 그 외 - MungpleDetailByPriceTagResDTO