### PR TITLE
FIX: 인증 등록 후 통계 데이터 수집 시 Lazy Loading 관련 오류 발생

### DIFF
--- a/src/main/java/com/delgo/reward/repository/CertRepository.java
+++ b/src/main/java/com/delgo/reward/repository/CertRepository.java
@@ -20,11 +20,11 @@ public interface CertRepository extends JpaRepository<Certification, Integer>, J
     Integer countByUserUserIdAndIsCorrect(int userId, boolean isCorrect);
     void deleteAllByUserUserId(int userId);
 
-    @EntityGraph(attributePaths = {"likeLists"})
+    @EntityGraph(attributePaths = {"photos"})
     @Query("SELECT DISTINCT c FROM Certification c JOIN FETCH c.user u JOIN FETCH u.pet WHERE c.certificationId IN :ids order by c.registDt desc")
     List<Certification> findCertByIds(@Param("ids") List<Integer> ids);
 
-    @EntityGraph(attributePaths = {"likeLists"})
+    @EntityGraph(attributePaths = {"photos"})
     @Query("SELECT c FROM Certification c JOIN FETCH c.user u JOIN FETCH u.pet WHERE c.certificationId = :certId")
     Optional<Certification> findCertByCertificationId(@Param("certId") Integer certId);
 
@@ -41,7 +41,7 @@ public interface CertRepository extends JpaRepository<Certification, Integer>, J
     List<Certification> findCertByDate(@Param("startDt") LocalDateTime startDt, @Param("endDt") LocalDateTime endDate);
 
     // 자신 거 조회라 is_correct_photo 없어도 됨.
-    @EntityGraph(attributePaths = {"user", "likeLists"})
+    @EntityGraph(attributePaths = {"user", "photos"})
     @Query(value = "select c from Certification c where c.user.userId = :userId and  c.registDt between :startDt and :endDt order by c.registDt desc")
     List<Certification> findCertByDateAndUser(@Param("userId") int userId, @Param("startDt") LocalDateTime startDt, @Param("endDt") LocalDateTime endDate);
 


### PR DESCRIPTION
 * API 속도를 위해 classification을 동적으로 구성
 * photos의 경우 지연로딩으로 설정되어 있는데 동적설정으로 인해 하이버네이트 세션이 닫힌 후에 로딩이 선언된다.
 * 해당 에러 발생해서 Fetch Join을 이용해 photos를 바로 조회하도록 했다.
 * 다만 List의 경우 2개 Fetch Join은 불가능해서 LikeList의 경우는 Lazy Loading하도록 선언했다.