### PR TITLE
ADD: 멍플 정렬 조건 추가 [전략 패턴 사용]

### DIFF
--- a/src/main/java/com/delgo/reward/comm/code/MungpleSort.java
+++ b/src/main/java/com/delgo/reward/comm/code/MungpleSort.java
@@ -1,0 +1,26 @@
+package com.delgo.reward.comm.code;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+
+@Getter
+public enum MungpleSort {
+    DISTANCE("DISTANCE","거리 순"),
+    CERT("CERT","인증 많은 순"),
+    BOOKMARK("BOOKMARK","저장 많은 순");
+
+    private final String code;
+    private final String desc;
+
+    MungpleSort(String code, String desc) {
+        this.code = code;
+        this.desc = desc;
+    }
+
+    // @RequestParam ENUM Parsing
+    @JsonCreator
+    public static MungpleSort from(String s) {
+        return MungpleSort.valueOf(s);
+    }
+}

--- a/src/main/java/com/delgo/reward/controller/MungpleController.java
+++ b/src/main/java/com/delgo/reward/controller/MungpleController.java
@@ -3,6 +3,7 @@ package com.delgo.reward.controller;
 import com.delgo.reward.comm.CommController;
 import com.delgo.reward.comm.code.APICode;
 import com.delgo.reward.comm.code.CategoryCode;
+import com.delgo.reward.comm.code.MungpleSort;
 import com.delgo.reward.comm.googlesheet.GoogleSheetService;
 import com.delgo.reward.mongoService.MongoMungpleService;
 import com.delgo.reward.record.mungple.MungpleDetailRecord;
@@ -51,8 +52,13 @@ public class MungpleController extends CommController {
      *
      */
     @GetMapping("/bookmark")
-    public ResponseEntity getMungplesByBookmark(@RequestParam int userId) {
-        return SuccessReturn(mongoMungpleService.getActiveMungpleByBookMark(userId));
+    public ResponseEntity getMungplesByBookmark(
+            @RequestParam int userId,
+            @RequestParam MungpleSort sort,
+            @RequestParam(required = false) String latitude,
+            @RequestParam(required = false) String longitude
+            ) {
+        return SuccessReturn(mongoMungpleService.getActiveMungpleByBookMark(userId, sort, latitude, longitude));
     }
 
     /**

--- a/src/main/java/com/delgo/reward/repository/BookmarkRepository.java
+++ b/src/main/java/com/delgo/reward/repository/BookmarkRepository.java
@@ -11,7 +11,10 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Integer> {
     Boolean existsByUserIdAndMungpleId(Integer userId, Integer mungpleId);
     Boolean existsByUserIdAndMungpleIdAndIsBookmarked(Integer userId, Integer mungpleId, boolean isBookmarked);
     Optional<Bookmark> findByUserIdAndMungpleId(Integer userId, Integer mungpleId);
-    List<Bookmark> findByUserId(Integer userId);
+
+    @Query("SELECT b FROM Bookmark b WHERE b.userId = :userId and b.isBookmarked = true")
+    List<Bookmark> findActiveBookmarkByUserId(Integer userId);
+
     @Query(value = "select count(b) from Bookmark b where b.mungpleId = :mungpleId and b.isBookmarked = true")
     int countOfActiveBookmarkByMungple(int mungpleId);
 }

--- a/src/main/java/com/delgo/reward/service/BookmarkService.java
+++ b/src/main/java/com/delgo/reward/service/BookmarkService.java
@@ -57,8 +57,8 @@ public class BookmarkService {
     /**
      * [userId] 북마크 가져오기
      */
-    public List<Bookmark> getBookmarkByUserId(int userId) {
-        return bookmarkRepository.findByUserId(userId);
+    public List<Bookmark> getActiveBookmarkByUserId(int userId) {
+        return bookmarkRepository.findActiveBookmarkByUserId(userId);
     }
 
     /**

--- a/src/main/java/com/delgo/reward/service/strategy/BookmarkCountSorting.java
+++ b/src/main/java/com/delgo/reward/service/strategy/BookmarkCountSorting.java
@@ -1,0 +1,33 @@
+package com.delgo.reward.service.strategy;
+
+import com.delgo.reward.mongoDomain.mungple.MongoMungple;
+import com.delgo.reward.repository.BookmarkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkCountSorting implements MungpleSortingStrategy {
+    private final BookmarkRepository bookmarkRepository;
+
+    @Override
+    public List<MongoMungple> sort(List<MongoMungple> mungpleList) {
+        // MariaDB에서 각 mungpleId별 Bookmark 개수 조회
+        Map<MongoMungple, Integer> countMap = new HashMap<>();
+        for(MongoMungple mungple : mungpleList) {
+            int count = bookmarkRepository.countOfActiveBookmarkByMungple(mungple.getMungpleId());
+            countMap.put(mungple, count);
+        }
+
+        // 저장 개수에 따라 mungpleId 리스트 정렬
+        return mungpleList.stream()
+                .sorted(Comparator.comparing(countMap::get))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/delgo/reward/service/strategy/CertCountSorting.java
+++ b/src/main/java/com/delgo/reward/service/strategy/CertCountSorting.java
@@ -1,0 +1,33 @@
+package com.delgo.reward.service.strategy;
+
+import com.delgo.reward.mongoDomain.mungple.MongoMungple;
+import com.delgo.reward.repository.CertRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CertCountSorting implements MungpleSortingStrategy {
+    private final CertRepository certRepository;
+
+    @Override
+    public List<MongoMungple> sort(List<MongoMungple> mungpleList) {
+        // MariaDB에서 각 mungpleId별 Certification 개수 조회
+        Map<MongoMungple, Integer> countMap = new HashMap<>();
+        for(MongoMungple mungple : mungpleList) {
+            int count = certRepository.countOfCertByMungple(mungple.getMungpleId());
+            countMap.put(mungple, count);
+        }
+
+        // 인증 개수에 따라 mungpleId 리스트 정렬
+        return mungpleList.stream()
+                .sorted(Comparator.comparing(countMap::get))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/delgo/reward/service/strategy/DistanceSorting.java
+++ b/src/main/java/com/delgo/reward/service/strategy/DistanceSorting.java
@@ -1,0 +1,48 @@
+package com.delgo.reward.service.strategy;
+
+import com.delgo.reward.mongoDomain.mungple.MongoMungple;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class DistanceSorting implements MungpleSortingStrategy {
+    private final double latitude;
+    private final double longitude;
+
+    public DistanceSorting(String latitude, String longitude) {
+        this.latitude = Double.parseDouble(latitude);
+        this.longitude = Double.parseDouble(longitude);
+    }
+
+    @Override
+    public List<MongoMungple> sort(List<MongoMungple> mungpleList) {
+        // 거리 순 정렬 구현
+        GeoJsonPoint targetPoint = new GeoJsonPoint(longitude, latitude);
+        return mungpleList.stream()
+                .sorted(Comparator.comparingDouble(mungple -> hversineCalculate(mungple.getLocation(), targetPoint)))
+                .toList();
+    }
+
+    // 2차 평면 거리 계산 함수
+    private double calculateDistance(GeoJsonPoint point1, GeoJsonPoint point2) {
+        double xDiff = point1.getX() - point2.getX();
+        double yDiff = point1.getY() - point2.getY();
+
+        return Math.sqrt(xDiff * xDiff + yDiff * yDiff);
+    }
+
+    // 2차 구 거리 계산 함수 (실제 거리에 가까움)
+    private double hversineCalculate(GeoJsonPoint point1, GeoJsonPoint point2) {
+        int EARTH_RADIUS = 6371; // 지구의 반경, km
+        double dLat = Math.toRadians(point2.getY() - point1.getY());
+        double dLng = Math.toRadians(point2.getX() - point1.getX());
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.cos(Math.toRadians(point1.getY())) * Math.cos(Math.toRadians(point2.getY())) *
+                        Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return EARTH_RADIUS * c;
+    }
+}

--- a/src/main/java/com/delgo/reward/service/strategy/MungpleSortingStrategy.java
+++ b/src/main/java/com/delgo/reward/service/strategy/MungpleSortingStrategy.java
@@ -1,0 +1,9 @@
+package com.delgo.reward.service.strategy;
+
+import com.delgo.reward.mongoDomain.mungple.MongoMungple;
+
+import java.util.List;
+
+public interface MungpleSortingStrategy {
+    List<MongoMungple> sort(List<MongoMungple> mungples);
+}


### PR DESCRIPTION
- 내가 저장한 멍플 조회 시 정렬 조건 별로 조회 결과 다름
[정렬 조건]
 * 거리순
 * 인증 많은 순
 * 저장 많이 한 순

 *** Mungple 조회 시에도 동일한 정렬 조건을 적용하기 위해 전략 패턴을 사용해서 구현

 - MungpleSort Enum 추가
 - 추후 Test Code 추가 예정