### PR TITLE
FIX: Mungple Sort 수정

### DIFF
--- a/src/main/java/com/delgo/reward/mongoService/MongoMungpleService.java
+++ b/src/main/java/com/delgo/reward/mongoService/MongoMungpleService.java
@@ -133,8 +133,8 @@ public class MongoMungpleService {
         // 조건에 맞게 정렬
         MungpleSortingStrategy sortingStrategy = switch (sort) {
             case DISTANCE -> new DistanceSorting(mungpleList, latitude, longitude);
-            case BOOKMARK -> new BookmarkCountSorting(mungpleList, countByBookmark.stream().map(MungpleCountDTO::getMungpleId).collect(Collectors.toMap(Function.identity(), Function.identity())));
-            case CERT -> new CertCountSorting(mungpleList, countByCert.stream().map(MungpleCountDTO::getMungpleId).collect(Collectors.toMap(Function.identity(), Function.identity())));
+            case BOOKMARK -> new BookmarkCountSorting(mungpleList, countByBookmark);
+            case CERT -> new CertCountSorting(mungpleList, countByCert);
             case NOT -> new NotSorting(mungpleList);
             default -> throw new IllegalArgumentException("Unknown sorting type: " + sort);
         };
@@ -179,7 +179,7 @@ public class MongoMungpleService {
     }
 
 
-    private List<MungpleResDTO> convertToMungpleResDTOs(List<MongoMungple> mungples) {
+    public List<MungpleResDTO> convertToMungpleResDTOs(List<MongoMungple> mungples) {
         Map<Integer, MungpleCountDTO> bookmarkCountsMap = bookmarkRepository.countBookmarksGroupedByMungpleId().stream().collect(Collectors.toMap(MungpleCountDTO::getMungpleId, Function.identity()));
         Map<Integer, MungpleCountDTO> certCountsMap = certRepository.countCertsGroupedByMungpleId().stream().collect(Collectors.toMap(MungpleCountDTO::getMungpleId, Function.identity()));
 

--- a/src/main/java/com/delgo/reward/repository/CertRepository.java
+++ b/src/main/java/com/delgo/reward/repository/CertRepository.java
@@ -90,10 +90,10 @@ public interface CertRepository extends JpaRepository<Certification, Integer>, J
     @Query(value = "select c from Certification c where c.user.userId = :userId and c.isCorrect = true")
     List<Certification> findCorrectCertByUserId(@Param("userId") int userId);
 
-    @Query(value = "select new com.delgo.reward.dto.user.UserVisitMungpleCountDTO(c.mungpleId, COUNT(c.mungpleId)) from Certification c where c.user.userId = :userId and c.mungpleId > 0 group by c.mungpleId having count(mungpleId) > 0 order by count(c.mungpleId) desc")
+    @Query(value = "select new com.delgo.reward.dto.user.UserVisitMungpleCountDTO(c.mungpleId, COUNT(c.mungpleId)) from Certification c where c.user.userId = :userId and c.mungpleId > 0 group by c.mungpleId having count(c.mungpleId) > 0 order by count(c.mungpleId) desc")
     List<UserVisitMungpleCountDTO> findVisitTop3MungpleIdByUserId(@Param("userId") int userId, Pageable pageable);
 
-    @Query(value = "select new com.delgo.reward.dto.mungple.MungpleCountDTO(c.mungpleId, count(c)) from Certification c where c.isCorrect = true group by c.mungpleId order by count(c) desc")
+    @Query(value = "select new com.delgo.reward.dto.mungple.MungpleCountDTO(c.mungpleId, count(c)) from Certification c where c.isCorrect = true and c.mungpleId != 0 group by c.mungpleId order by count(c) desc")
     List<MungpleCountDTO> countCertsGroupedByMungpleId();
   
     // ---------------------------------------- Map TEST ----------------------------------------

--- a/src/main/java/com/delgo/reward/service/strategy/CertCountSorting.java
+++ b/src/main/java/com/delgo/reward/service/strategy/CertCountSorting.java
@@ -1,31 +1,38 @@
 package com.delgo.reward.service.strategy;
 
+import com.delgo.reward.dto.mungple.MungpleCountDTO;
 import com.delgo.reward.mongoDomain.mungple.MongoMungple;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CertCountSorting implements MungpleSortingStrategy {
     private final List<MongoMungple> mungpleList;
-    private final Map<Integer,Integer> sortedMungpleId;
+    private final  List<MungpleCountDTO> countByCert;
 
-    public CertCountSorting(List<MongoMungple> mungpleList, Map<Integer,Integer> sortedMungpleId){
+    public CertCountSorting(List<MongoMungple> mungpleList, List<MungpleCountDTO> countByCert){
         this.mungpleList = mungpleList;
-        this.sortedMungpleId = sortedMungpleId;
+        this.countByCert = countByCert;
     }
 
     @Override
     public List<MongoMungple> sort() {
-        mungpleList.sort((m1, m2) -> {
-            int index1 = sortedMungpleId.getOrDefault(m1.getMungpleId(), -1);
-            int index2 = sortedMungpleId.getOrDefault(m2.getMungpleId(), -1);
+        Map<Integer, MongoMungple> mungpleMap = mungpleList.stream()
+                .collect(Collectors.toMap(
+                        MongoMungple::getMungpleId, // 키로 사용할 함수
+                        Function.identity()        // 값으로 사용할 함수
+                ));
 
-            if (index1 == index2) return 0; // 둘 다 없을 때 (-1 == -1)
-            if (index1 == -1) return 1;     // m1이 없을 때
-            if (index2 == -1) return -1;    // m2가 없을 때
-
-            return Integer.compare(index1, index2);
-        });
-
-        return mungpleList;
+        return Stream.concat(
+                        countByCert.stream()
+                                .map(MungpleCountDTO::getMungpleId)
+                                .map(mungpleMap::get), // 해당 부분에서 Null 생성될 수 있음.
+                        mungpleList.stream())
+                .filter(Objects::nonNull) // null 값 제거 // isActive = false인 멍플의 인증이 존재할 경우 NullException 발생
+                .distinct()
+                .toList();
     }
 }

--- a/src/test/java/com/delgo/reward/MongoMungpleTest.java
+++ b/src/test/java/com/delgo/reward/MongoMungpleTest.java
@@ -1,9 +1,16 @@
 package com.delgo.reward;
 
 
+import com.delgo.reward.dto.mungple.MungpleCountDTO;
+import com.delgo.reward.dto.mungple.MungpleResDTO;
+import com.delgo.reward.mongoDomain.mungple.MongoMungple;
 import com.delgo.reward.mongoRepository.MongoMungpleRepository;
-import com.delgo.reward.mongoRepository.MungpleDetailRepository;
 import com.delgo.reward.mongoService.MongoMungpleService;
+import com.delgo.reward.repository.BookmarkRepository;
+import com.delgo.reward.repository.CertRepository;
+import com.delgo.reward.service.strategy.BookmarkCountSorting;
+import com.delgo.reward.service.strategy.CertCountSorting;
+import com.delgo.reward.service.strategy.MungpleSortingStrategy;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +31,10 @@ public class MongoMungpleTest {
     private MongoMungpleRepository mongoMungpleRepository;
 
     @Autowired
-    private MungpleDetailRepository mungpleDetailRepository;
+    private BookmarkRepository bookmarkRepository;
+
+    @Autowired
+    private CertRepository certRepository;
 
     @Test
     public void deleteAllMongoMunple(){
@@ -57,5 +67,43 @@ public class MongoMungpleTest {
         String longitude = "127.1412807";
 
         mongoMungpleService.findWithin3Km(latitude,longitude);
+    }
+
+    @Test
+    public void BookMarkCountSorting_성공한다() {
+        //whne
+        List<MongoMungple> mungpleList = mongoMungpleRepository.findByIsActive(true);
+
+        // DB Data 조회
+        List<MungpleCountDTO> countByBookmark = bookmarkRepository.countBookmarksGroupedByMungpleId();
+
+        // 조건에 맞게 정렬
+        MungpleSortingStrategy sortingStrategy = new BookmarkCountSorting(mungpleList, countByBookmark);
+        List<MungpleResDTO> mungpleResDTOS = mongoMungpleService.convertToMungpleResDTOs(sortingStrategy.sort());
+        for (MungpleResDTO mungple : mungpleResDTOS) {
+            System.out.println("mungple = " + mungple.getPlaceName() + " count : " + mungple.getBookmarkCount());
+        }
+    }
+
+    @Test
+    public void CertCountSorting_성공한다() {
+        //whne
+        List<MongoMungple> mungpleList = mongoMungpleRepository.findByIsActive(true);
+
+        // DB Data 조회
+        List<MungpleCountDTO> countByCert = certRepository.countCertsGroupedByMungpleId();
+
+        // 조건에 맞게 정렬
+        MungpleSortingStrategy sortingStrategy = new CertCountSorting(mungpleList, countByCert);
+        List<MongoMungple> sortedMungpleList = sortingStrategy.sort();
+
+        List<MungpleResDTO> mungpleResDTOS = mongoMungpleService.convertToMungpleResDTOs(sortedMungpleList);
+        for (MungpleResDTO mungple : mungpleResDTOS) {
+            System.out.println("mungple = " + mungple.getPlaceName() + " count : " + mungple.getCertCount());
+        }
+
+        int count = mungpleResDTOS.size();
+        System.out.println("count 1 = " + count);
+        System.out.println("count 2 = " + mungpleList.size());
     }
 }


### PR DESCRIPTION
- 기존 정렬 로직 제대로 동작 안함.

1. 기존 Mungple List Map으로 변환
2. Sorted(조건)DTOList에서 mungpleId로 1번 Map에서 Mungple 가져와서 List로 만듬
3. 2번 리스트에 없는 Mungple 들을 위해 1번과 addAll()
4. 중복 제거, null 제거

순으로 로직 변경